### PR TITLE
Fireboard.js Drive Crash Fix

### DIFF
--- a/lib/fireboard/Drive.js
+++ b/lib/fireboard/Drive.js
@@ -31,7 +31,7 @@ class Drive extends LoggingDevice {
 
     updateDevice(drivelog) {
         if (!drivelog) {
-            return;
+            return this.getUpdateLog();
         }        
 
         const jsonRaw = JSON.parse(drivelog.jsonraw);


### PR DESCRIPTION
Always return an update log even if empty

Fixes #22 