### PR TITLE
fix: add ability to handle anonymous mqtt connections

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -178,6 +178,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
+name = "config-derive"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c547326a30684f853601fb959cc8ecbd0d72abbdd27ba634850a918fa29afc4"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -226,10 +238,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "env_struct"
-version = "0.1.4"
+name = "envy"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7dd18b6671ff89467b58616842422e061a7608d04ba5f747bce0b983e010b93"
+checksum = "3f47e0157f2cb54f5ae1bd371b30a2ae4311e1c028f575cd4e81de7353215965"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "errno"
@@ -255,7 +270,6 @@ dependencies = [
  "bytes",
  "chrono",
  "env_logger",
- "env_struct",
  "human_bytes",
  "log",
  "memory-stats",
@@ -265,6 +279,7 @@ dependencies = [
  "serde_json",
  "serde_repr",
  "tokio",
+ "twelf",
  "url",
 ]
 
@@ -365,6 +380,12 @@ name = "gimli"
 version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
+
+[[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
@@ -684,7 +705,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -751,7 +772,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -1045,7 +1066,7 @@ checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -1067,7 +1088,7 @@ checksum = "0b2e6b945e9d3df726b65d6ee24060aff8e3533d431f677a9695db04eff9dfdb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -1130,6 +1151,17 @@ name = "subtle"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "syn"
@@ -1198,7 +1230,7 @@ checksum = "a953cb265bef375dae3de6663da4d3804eee9682ea80d8e2542529b73c531c81"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -1243,7 +1275,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -1320,6 +1352,20 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "twelf"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16de46d08a9d3a25e0a65bb70090797b970bd1e95d72872567ba8d02c0b03bdf"
+dependencies = [
+ "config-derive",
+ "envy",
+ "log",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
 
 [[package]]
 name = "unicode-bidi"
@@ -1407,7 +1453,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.52",
  "wasm-bindgen-shared",
 ]
 
@@ -1441,7 +1487,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.52",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ pretty_print_json_logs = []
 
 [dependencies]
 anyhow = "1.0.80"
-env_struct = "0.1.4"
 tokio = { version = "1", features = ["full"] }
 log = "0.4.21"
 env_logger = "0.11.3"
@@ -28,6 +27,7 @@ chrono = { version = "0.4.31", default-features = false, features = [
     "serde",
     "clock"
 ]}
+twelf = { version = "0.15.0", default-features = false, features = ["env", "default_trait"]}
 
 [profile.dev]
 debug = true

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,7 +32,10 @@ async fn main() {
     
     let cfg = load_cfg_from_env();
 
-    debug!("config loaded successfully");
+    
+
+    debug!("config loaded successfully: {}", serde_json::to_string_pretty(&cfg).unwrap());
+    
 
     let (tx_mqtt, mut rx_mqtt) = mpsc::channel::<MQTTAction>(16);
     let mut watcher = {
@@ -46,13 +49,14 @@ async fn main() {
 
     let (mqtt_client, mut mqtt_eventloop) = {
         let cfg = cfg.clone();
+        info!("connecting to mqtt broker at {}:{} with clientId {}", cfg.mqtt_host, cfg.mqtt_port, cfg.mqtt_clientid);
         let mut mqtt_options = MqttOptions::new(
             cfg.mqtt_clientid.clone(),
             cfg.mqtt_host.clone(),
             cfg.mqtt_port,
         );
-        if let Some((username, password)) = cfg.mqtt_credentials {
-            mqtt_options.set_credentials(username, password);
+        if let Some(mqtt_credentials) = cfg.mqtt_credentials {
+            mqtt_options.set_credentials(mqtt_credentials.username, mqtt_credentials.password);
         }
         mqtt_options.set_last_will(watcher.get_last_will());
         AsyncClient::new(mqtt_options, 16)


### PR DESCRIPTION
Resolves #42 

Related to gordlea/home-assistant-addons#55

This updates fireboard2mqtt to allow it to work with anonymous mqtt connections.