### PR TITLE
fix: add extra debug logging to fireboard_api

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,6 @@ strip = false
 debug = 0
 strip = true
 lto = true
-opt-level = 3
+opt-level = "s"
 codegen-units = 1
 panic = "abort"

--- a/src/fireboard_api.rs
+++ b/src/fireboard_api.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use chrono::{DateTime, Local};
-use log::error;
+use log::{debug, error};
 use reqwest::{
     header::{HeaderMap, HeaderValue},
     Url,
@@ -231,6 +231,7 @@ impl<'c> DevicesEndpoint<'c> {
             ))
         } else {
             let response_text = response.text().await?;
+            debug!("Raw response body: {}", response_text);
             // let v: Value = serde_json::from_str(response_text.as_str())?;
             let devices 
                 = serde_json::from_str::<Vec<FireboardApiDevice>>(response_text.as_str());


### PR DESCRIPTION
Relates to #43 

Basically logs the raw json from the api list devices call.