### PR TITLE
fix: fixes erroneous json errors in home assistant core log

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,5 @@
 {
     "recommendations": [
-        "mkhl.direnv",
         "editorconfig.editorconfig",
         "serayuzgur.crates",
         "vadimcn.vscode-lldb",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -19,6 +19,7 @@
                     "kind": "bin"
                 }
             },
+            "envFile": "${workspaceFolder}/.env",
             "args": [],
             "cwd": "${workspaceFolder}"
         },

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -278,6 +278,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_repr",
+ "strum",
  "tokio",
  "twelf",
  "url",
@@ -1006,6 +1007,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
+
+[[package]]
 name = "ryu"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1144,6 +1151,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 dependencies = [
  "lock_api",
+]
+
+[[package]]
+name = "strum"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d8cec3501a5194c432b2b7976db6b7d10ec95c253208b45f83f7136aa985e29"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6cf59daf282c0a494ba14fd21610a0325f9f90ec9d1231dea26bcb1d696c946"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.52",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ chrono = { version = "0.4.31", default-features = false, features = [
     "clock"
 ]}
 twelf = { version = "0.15.0", default-features = false, features = ["env", "default_trait"]}
+strum = { version = "0.26.2", features = ["derive"] }
 
 [profile.dev]
 debug = true

--- a/src/fireboard_api.rs
+++ b/src/fireboard_api.rs
@@ -7,6 +7,7 @@ use reqwest::{
 };
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::{json, Value};
+use strum::Display;
 use std::sync::Arc;
 extern crate serde_json;
 use serde_repr::{Deserialize_repr, Serialize_repr};
@@ -84,27 +85,23 @@ where
 }
 
 
-#[derive(Serialize_repr, Deserialize_repr, PartialEq, Debug, Copy, Clone)]
+#[derive(Serialize_repr, Deserialize_repr, PartialEq, Debug, Copy, Clone, Display)]
 #[repr(u8)]
 pub enum DegreeType {
+    #[strum(to_string = "°C")]
     Celcius = 1,
+    #[strum(to_string = "°F")]
     Fahrenheit = 2,
 }
 
-impl ToString for DegreeType {
-    fn to_string(&self) -> String {
-        match self {
-            DegreeType::Celcius => "°C".to_string(),
-            DegreeType::Fahrenheit => "°F".to_string(),
-        }
-    }
-}
-
-#[derive(Serialize_repr, Deserialize_repr, PartialEq, Debug, Copy, Clone)]
+#[derive(Serialize_repr, Deserialize_repr, PartialEq, Debug, Copy, Clone, Display)]
 #[repr(u8)]
 pub enum DriveModeType {
+    #[strum(to_string = "off")]
     Off = 0,
+    #[strum(to_string = "manual")]
     Manual = 1,
+    #[strum(to_string = "auto")]
     Auto = 2,
 }
 
@@ -115,16 +112,6 @@ impl From<String> for DriveModeType {
             "manual" => DriveModeType::Manual,
             "auto" => DriveModeType::Auto,
             _ => panic!("Invalid DriveModeType: {}", s),
-        }
-    }
-}
-
-impl ToString for DriveModeType {
-    fn to_string(&self) -> String {
-        match self {
-            DriveModeType::Off => "off".to_string(),
-            DriveModeType::Manual => "manual".to_string(),
-            DriveModeType::Auto => "auto".to_string(),
         }
     }
 }

--- a/src/fireboard_watcher.rs
+++ b/src/fireboard_watcher.rs
@@ -307,7 +307,8 @@ impl FireboardWatcher {
                 state_topic: format!("{}/state", channel_topic),
                 unit_of_measurement: Some(device.degreetype.to_string()),
                 device: parent_device.clone(),
-                // expires_after: Some(60),
+                // TODO make this configurable?
+                expires_after: Some(600),
                 ..MQTTDiscoverySensor::default()
             };
             self.tx
@@ -341,7 +342,8 @@ impl FireboardWatcher {
             device_class: None,
             qos: 0,
             icon: Some("mdi:fan".to_string()),
-            // icon: None,
+            // TODO make this configurable?
+            expires_after: Some(600),
             state_topic: self.get_topic_device_drive_state(&hardware_id),
             unit_of_measurement: Some("%".to_string()),
             device: parent_device.clone(),
@@ -477,6 +479,7 @@ impl FireboardWatcher {
         let drive_enabled = self.cfg.fireboard_enable_drive;
         let result = self.fb_client.devices().list().await;
         if let Ok(returned_devices) = result {
+            info!("{} devices fetched successfully", returned_devices.len());
             #[cfg(feature = "pretty_print_json_logs")]
             trace!(
                 "devices fetched successfully: {}",
@@ -578,16 +581,16 @@ impl FireboardWatcher {
                                 .unwrap();
                         } else {
                             // channel is offline
-                            self.tx
-                                .send(MQTTAction::Publish {
-                                    topic: format!("{}/state", channel_topic),
-                                    qos: QoS::AtMostOnce,
-                                    retain: false,
-                                    payload: "".into(),
-                                    props: None,
-                                })
-                                .await
-                                .unwrap();
+                            // self.tx
+                            //     .send(MQTTAction::Publish {
+                            //         topic: format!("{}/state", channel_topic),
+                            //         qos: QoS::AtMostOnce,
+                            //         retain: false,
+                            //         payload: "".into(),
+                            //         props: None,
+                            //     })
+                            //     .await
+                            //     .unwrap();
                         }
                     }
                 }
@@ -743,27 +746,27 @@ impl FireboardWatcher {
                                 .await
                                 .unwrap();
 
-                            self.tx
-                                .send(MQTTAction::Publish {
-                                    topic: self.get_topic_device_drive_state(&hardware_id),
-                                    qos: QoS::AtMostOnce,
-                                    retain: false,
-                                    payload: "".into(),
-                                    props: None,
-                                })
-                                .await
-                                .unwrap();
+                            // self.tx
+                            //     .send(MQTTAction::Publish {
+                            //         topic: self.get_topic_device_drive_state(&hardware_id),
+                            //         qos: QoS::AtMostOnce,
+                            //         retain: false,
+                            //         payload: "".into(),
+                            //         props: None,
+                            //     })
+                            //     .await
+                            //     .unwrap();
 
-                            self.tx
-                                .send(MQTTAction::Publish {
-                                    topic: self.get_topic_device_drive_attributes(&hardware_id),
-                                    qos: QoS::AtMostOnce,
-                                    retain: false,
-                                    payload: "".into(),
-                                    props: None,
-                                })
-                                .await
-                                .unwrap();
+                            // self.tx
+                            //     .send(MQTTAction::Publish {
+                            //         topic: self.get_topic_device_drive_attributes(&hardware_id),
+                            //         qos: QoS::AtMostOnce,
+                            //         retain: false,
+                            //         payload: "".into(),
+                            //         props: None,
+                            //     })
+                            //     .await
+                            //     .unwrap();
                         }
                     } else if let Err(err) = rt_drivelog_request {
                         error!("Error fetching realtime drivelog: {:?}", err);

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@ use crate::{
 };
 use env_logger::{Builder, Env};
 use human_bytes::human_bytes;
-use log::{debug, error, info, trace};
+use log::{debug, error, info, trace, warn};
 use memory_stats::memory_stats;
 use rumqttc::v5::{AsyncClient, MqttOptions};
 use std::process;
@@ -64,6 +64,8 @@ async fn main() {
 
     tokio::spawn(async move {
         while let Some(action) = rx_mqtt.recv().await {
+            // eprintln!("mqtt action: {:?}", action);
+
             match action {
                 MQTTAction::Publish {
                     topic,
@@ -72,6 +74,10 @@ async fn main() {
                     payload,
                     props,
                 } => {
+                    trace!("publishing to mqtt: topic={:?}, qos={:?}, retain={:?}, payload={:?}, props={:?}", topic, qos, retain, payload, props);
+                    if payload.is_empty() {
+                        warn!("publishing empty payload to topic: {}", topic)
+                    }
                     if let Some(properties) = props {
                         mqtt_client
                             .publish_with_properties(topic, qos, retain, payload, properties)


### PR DESCRIPTION
Fixes #51 

@mattdevo1 This PR should fix the issue, it was actually not too hard to find, I was setting a blank string for state when a channel or the drive was offline, as that deletes the entry in mqtt, but home assistant doesn't appreciate it. 

Instead, now I'm trying out the expires_after property. I will do a release later today.